### PR TITLE
feat : response 에러 메세지 추가 및 유효성 검사 로직 추가

### DIFF
--- a/app/(backend)/auths/login/LoginModel.ts
+++ b/app/(backend)/auths/login/LoginModel.ts
@@ -8,15 +8,17 @@ export interface LoginRequest {
 
 export interface LoginDBResponse {
   id: number;
-  loginId: string;
+  loginId: string; // 실제 로그인에 사용된 ID (전화번호 또는 이메일)
   password: string;
 }
 
+export interface LoginResponseWithoutPassword {
+  id: number;
+  loginId: string;
+}
+
 export interface LoginResponseDTO {
-  user: {
-    id: number;
-    loginId: string;
-  };
+  user: LoginResponseWithoutPassword;
   accessToken: string;
   refreshToken: string;
 }

--- a/app/(backend)/auths/login/applications/dtos/LoginResponse.ts
+++ b/app/(backend)/auths/login/applications/dtos/LoginResponse.ts
@@ -1,6 +1,8 @@
+import { LoginResponseWithoutPassword } from '../../LoginModel';
+
 export class LoginResponseDTO {
   constructor(
-    public user: { id: number; loginId: string },
+    public user: LoginResponseWithoutPassword,
     public accessToken: string,
     public refreshToken: string
   ) {}

--- a/app/(backend)/auths/login/applications/usecases/LoginUseCase.ts
+++ b/app/(backend)/auths/login/applications/usecases/LoginUseCase.ts
@@ -12,19 +12,35 @@ export class LoginUseCase {
   }
 
   async execute(request: LoginRequest): Promise<LoginResponseDTO> {
+    // 입력 검증
+    if (!request.loginId || !request.password) {
+      throw new Error('로그인 ID와 비밀번호를 입력해주세요.');
+    }
+
+    if (
+      typeof request.loginId !== 'string' ||
+      typeof request.password !== 'string'
+    ) {
+      throw new Error('잘못된 입력 형식입니다.');
+    }
+
+    if (
+      request.loginId.trim().length === 0 ||
+      request.password.trim().length === 0
+    ) {
+      throw new Error('로그인 ID와 비밀번호를 입력해주세요.');
+    }
+
     if (!this.loginRepository) {
       throw new Error('LoginRepository가 초기화되지 않았습니다.');
     }
 
     // 1. 유저 조회 (phoneNumber 또는 email)
     const user = await this.loginRepository.findUserByLoginId(request.loginId);
-    if (!user) {
-      throw new Error('존재하지 않는 사용자입니다.');
-    }
 
-    // 2. 비밀번호 검증 (실제 서비스에서는 bcrypt 등으로 해시 비교)
-    if (user.password !== request.password) {
-      throw new Error('비밀번호가 일치하지 않습니다.');
+    // 2. 유효성 검증
+    if (!user || user.password !== request.password) {
+      throw new Error('로그인 정보가 올바르지 않습니다.');
     }
 
     // 3. 토큰 발급

--- a/app/(backend)/auths/login/infrastructures/mappers/LoginMapper.ts
+++ b/app/(backend)/auths/login/infrastructures/mappers/LoginMapper.ts
@@ -1,4 +1,7 @@
-import { LoginDBResponse } from '../../LoginModel';
+import {
+  LoginDBResponse,
+  LoginResponseWithoutPassword,
+} from '../../LoginModel';
 import { LoginResponseDTO } from '../../applications/dtos/LoginResponse';
 import { LoginUserEntity } from '../../domains/entities/LoginUserEntity';
 
@@ -8,8 +11,13 @@ export class LoginMapper {
     accessToken: string,
     refreshToken: string
   ) {
+    const LoginDataWithoutPassword: LoginResponseWithoutPassword = {
+      id: user.id,
+      loginId: user.loginId,
+    };
+
     return new LoginResponseDTO(
-      { id: user.id, loginId: user.loginId },
+      LoginDataWithoutPassword,
       accessToken,
       refreshToken
     );

--- a/app/api/user/login/route.ts
+++ b/app/api/user/login/route.ts
@@ -6,24 +6,53 @@ import { NextRequest, NextResponse } from 'next/server';
 
 export async function POST(req: NextRequest) {
   try {
-    const { loginId, password } = await req.json();
+    const body = await req.json();
+    const { loginId, password } = body;
+
+    if (!loginId || !password) {
+      return NextResponse.json(
+        { error: '로그인 ID와 비밀번호는 필수입니다.' },
+        { status: 400 }
+      );
+    }
+
     const usecase = new LoginUseCase(new LoginRepository());
     const result = await usecase.execute(
       new LoginRequestDTO(loginId, password)
     );
-
-    const { ...userWithoutPassword } = result.user;
 
     const cookieStore = await cookies();
     cookieStore.set('access-token', result.accessToken);
     cookieStore.set('refresh-token', result.refreshToken);
 
     return NextResponse.json({
-      user: userWithoutPassword,
+      user: result.user,
       accessToken: result.accessToken,
       refreshToken: result.refreshToken,
     });
-  } catch (e: any) {
-    return NextResponse.json({ error: e.message }, { status: 401 });
+  } catch (e: unknown) {
+    const errorMessage =
+      e instanceof Error ? e.message : '로그인 처리 중 오류가 발생했습니다.';
+
+    // 보안을 위해 모든 인증 실패는 동일한 메시지와 상태 코드 사용
+    if (errorMessage.includes('로그인 정보가 올바르지 않습니다')) {
+      return NextResponse.json(
+        { error: '로그인 정보가 올바르지 않습니다.' },
+        { status: 401 }
+      );
+    }
+
+    // 입력 검증 오류
+    if (
+      errorMessage.includes('로그인 ID와 비밀번호를 입력해주세요') ||
+      errorMessage.includes('잘못된 입력 형식입니다')
+    ) {
+      return NextResponse.json({ error: errorMessage }, { status: 400 });
+    }
+
+    return NextResponse.json(
+      { error: '로그인 처리 중 오류가 발생했습니다.' },
+      { status: 500 }
+    );
   }
 }

--- a/lib/jwt.ts
+++ b/lib/jwt.ts
@@ -1,16 +1,22 @@
 import jwt from 'jsonwebtoken';
 
-const ACCESS_SECRET = process.env.ACCESS_SECRET as string;
-const REFRESH_SECRET = process.env.REFRESH_SECRET as string;
+const ACCESS_SECRET = process.env.ACCESS_SECRET;
+const REFRESH_SECRET = process.env.REFRESH_SECRET;
 
 if (!ACCESS_SECRET || !REFRESH_SECRET) {
   throw new Error('JWT 시크릿 키가 환경 변수에 설정되지 않았습니다.');
 }
 
-export function generateAccessToken(payload: object) {
-  return jwt.sign(payload, ACCESS_SECRET, { expiresIn: '15m' });
+export function generateAccessToken(payload: Record<string, unknown>) {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('유효하지 않은 페이로드입니다.');
+  }
+  return jwt.sign(payload, ACCESS_SECRET as string, { expiresIn: '15m' });
 }
 
-export function generateRefreshToken(payload: object) {
-  return jwt.sign(payload, REFRESH_SECRET, { expiresIn: '7d' });
+export function generateRefreshToken(payload: Record<string, unknown>) {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('유효하지 않은 페이로드입니다.');
+  }
+  return jwt.sign(payload, REFRESH_SECRET as string, { expiresIn: '7d' });
 }


### PR DESCRIPTION
## Summary
- 유효성 검사 로직 추가
- response 에러 코드와 메세지 추가
- response body 데이터에 적용되는 비밀번호가 제외된 사용자 데이터를 별도에 interface로 생성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 로그인 요청 시 입력값(`loginId`, `password`)의 유효성을 더욱 엄격하게 검사하고, 누락 시 명확한 오류 메시지(400 에러)로 응답합니다.
  * 로그인 실패 시(아이디 또는 비밀번호 불일치) 통일된 오류 메시지(401 에러)로 응답합니다.
  * 서버 내부 오류와 입력 오류를 구분하여 각각 적절한 상태 코드와 메시지로 응답합니다.

* **리팩터**
  * 로그인 응답에서 비밀번호를 제외한 사용자 정보만 반환하도록 구조를 개선했습니다.
  * 토큰 생성 시 입력값의 유효성을 추가로 검증합니다.

* **문서화**
  * 로그인 관련 데이터 구조에 대한 설명 주석이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->